### PR TITLE
Adds support for nullable reference types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-rc.2] - 2023-01-17
+
+### Added
+
+- Adds support for nullabe reference types
+
 ## [1.0.0-rc.1] - 2022-12-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [1.0.0-rc.2] - 2023-01-17
+## [1.0.0-rc.3] - 2023-01-17
 
 ### Added
 

--- a/Microsoft.Kiota.Authentication.Azure.Tests/Microsoft.Kiota.Authentication.Azure.Tests.csproj
+++ b/Microsoft.Kiota.Authentication.Azure.Tests/Microsoft.Kiota.Authentication.Azure.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AzureIdentityAccessTokenProvider.cs
+++ b/src/AzureIdentityAccessTokenProvider.cs
@@ -22,7 +22,7 @@ public class AzureIdentityAccessTokenProvider : IAccessTokenProvider, IDisposabl
     private readonly ActivitySource _activitySource;
     private readonly HashSet<string> _scopes;
     /// <inheritdoc />
-    public AllowedHostsValidator AllowedHostsValidator { get; private set; }
+    public AllowedHostsValidator AllowedHostsValidator { get; protected set; }
 
     /// <summary>
     /// The <see cref="AzureIdentityAccessTokenProvider"/> constructor

--- a/src/AzureIdentityAccessTokenProvider.cs
+++ b/src/AzureIdentityAccessTokenProvider.cs
@@ -32,7 +32,7 @@ public class AzureIdentityAccessTokenProvider : IAccessTokenProvider, IDisposabl
     /// <param name="allowedHosts">The list of allowed hosts for which to request access tokens.</param>
     /// <param name="scopes">The scopes to request the access token for.</param>
     /// <param name="observabilityOptions">The observability options to use for the authentication provider.</param>
-    public AzureIdentityAccessTokenProvider(TokenCredential credential, string [] allowedHosts = null, ObservabilityOptions observabilityOptions = null, params string[] scopes)
+    public AzureIdentityAccessTokenProvider(TokenCredential credential, string []? allowedHosts = null, ObservabilityOptions? observabilityOptions = null, params string[] scopes)
     {
         _credential = credential ?? throw new ArgumentNullException(nameof(credential));
 
@@ -56,7 +56,7 @@ public class AzureIdentityAccessTokenProvider : IAccessTokenProvider, IDisposabl
     private const string ClaimsKey = "claims";
 
     /// <inheritdoc/>
-    public async Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> additionalAuthenticationContext = default, CancellationToken cancellationToken = default)
+    public async Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = default, CancellationToken cancellationToken = default)
     {
         using var span = _activitySource?.StartActivity(nameof(GetAuthorizationTokenAsync));
         if(!AllowedHostsValidator.IsUrlHostValid(uri)) {
@@ -71,7 +71,7 @@ public class AzureIdentityAccessTokenProvider : IAccessTokenProvider, IDisposabl
 
         span?.SetTag("com.microsoft.kiota.authentication.is_url_valid", true);
 
-        string decodedClaim = null;
+        string? decodedClaim = null;
         if (additionalAuthenticationContext is not null &&
                     additionalAuthenticationContext.ContainsKey(ClaimsKey) &&
                     additionalAuthenticationContext[ClaimsKey] is string claims) {
@@ -82,7 +82,7 @@ public class AzureIdentityAccessTokenProvider : IAccessTokenProvider, IDisposabl
             span?.SetTag("com.microsoft.kiota.authentication.additional_claims_provided", false);
 
         span?.SetTag("com.microsoft.kiota.authentication.scopes", string.Join(",", _scopes));
-        var result = await this._credential.GetTokenAsync(new TokenRequestContext(_scopes.ToArray(), claims: decodedClaim), cancellationToken); //TODO: we might have to bubble that up for native apps or backend web apps to avoid blocking the UI/getting an exception
+        var result = await this._credential.GetTokenAsync(new TokenRequestContext(_scopes.ToArray(), claims: decodedClaim), cancellationToken); ; //TODO: we might have to bubble that up for native apps or backend web apps to avoid blocking the UI/getting an exception
         return result.Token;
     }
     /// <inheritdoc/>

--- a/src/AzureIdentityAuthenticationProvider.cs
+++ b/src/AzureIdentityAuthenticationProvider.cs
@@ -18,7 +18,8 @@ public class AzureIdentityAuthenticationProvider : BaseBearerTokenAuthentication
     /// <param name="allowedHosts">The list of allowed hosts for which to request access tokens.</param>
     /// <param name="scopes">The scopes to request the access token for.</param>
     /// <param name="observabilityOptions">The observability options to use for the authentication provider.</param>
-    public AzureIdentityAuthenticationProvider(TokenCredential credential, string[] allowedHosts = null, ObservabilityOptions observabilityOptions = null, params string[] scopes) : base(new AzureIdentityAccessTokenProvider(credential, allowedHosts, observabilityOptions, scopes))
+    public AzureIdentityAuthenticationProvider(TokenCredential credential, string[]? allowedHosts = null, ObservabilityOptions? observabilityOptions = null, params string[] scopes)
+        : base(new AzureIdentityAccessTokenProvider(credential, allowedHosts, observabilityOptions, scopes))
     {
     }
 }

--- a/src/Microsoft.Kiota.Authentication.Azure.csproj
+++ b/src/Microsoft.Kiota.Authentication.Azure.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Kiota Azure Identity Authentication Library for dotnet</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-authentication-azure-dotnet</RepositoryUrl>
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>rc.1</VersionSuffix>
+    <VersionSuffix>rc.2</VersionSuffix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -22,8 +22,11 @@
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageReleaseNotes>
-        - Release candidate 1
+        https://github.com/microsoft/kiota-abstractions-dotnet/releases
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -33,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Azure.Core" Version="1.27.0" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-rc.3" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-rc.4" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/Microsoft.Kiota.Authentication.Azure.csproj
+++ b/src/Microsoft.Kiota.Authentication.Azure.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Kiota Azure Identity Authentication Library for dotnet</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-authentication-azure-dotnet</RepositoryUrl>
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>rc.2</VersionSuffix>
+    <VersionSuffix>rc.3</VersionSuffix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Enable this line once we go live to prevent breaking changes -->

--- a/src/ObservabilityOptions.cs
+++ b/src/ObservabilityOptions.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -9,7 +9,7 @@ namespace Microsoft.Kiota.Authentication.Azure;
 /// Holds the tracing, metrics and logging configuration for the authentication provider
 /// </summary>
 public class ObservabilityOptions {
-    private static readonly Lazy<string> _name = new Lazy<string>(() => typeof(ObservabilityOptions).Namespace);
+    private static readonly Lazy<string> _name = new Lazy<string>(() => typeof(ObservabilityOptions).Namespace!);
     /// <summary>
     /// Gets the observability name to use for the tracer
     /// </summary>


### PR DESCRIPTION
This PR is part of https://github.com/microsoft/kiota/issues/2073

Changes include: -

- Adds nullable markers to APIs that can return null. 
- Adds nullable feature in project as well as net6.0 target to allow for proper feature functionality. Also sets `TreatWarningsAsErrors` to alleviate any potential mistakes being ignored.