### PR TITLE
Use sliding version for System.Diagnostics.DiagnosticSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.1] - 2023-03-10
+
+### Changed
+
+- Update minimum version of [`System.Diagnostics.DiagnosticSource`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource) to `6.0.0`.
+
 ## [1.0.0] - 2023-02-27
 
 ### Added

--- a/src/Microsoft.Kiota.Authentication.Azure.csproj
+++ b/src/Microsoft.Kiota.Authentication.Azure.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -36,8 +36,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Azure.Core" Version="1.29.0" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[6.0,8.0)" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1670 and https://github.com/microsoft/kiota-serialization-json-dotnet/issues/69

Conflicting libraries for users on .NET 6 run into issues when forced to use the v7 of the library.