### PR TITLE
Creates new release with updated Azure.Core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.0.2] - 2023-03-24
+
+### Changed
+
+- Update minimum version of [`Azure.Core`]([https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource](https://www.nuget.org/packages/Azure.Core)) to `1.3.0` to fix Azure.Blob storage issues. https://github.com/Azure/azure-sdk-for-net/issues/35010
+
 ### Changed
 
 ## [1.0.1] - 2023-03-10

--- a/src/Microsoft.Kiota.Authentication.Azure.csproj
+++ b/src/Microsoft.Kiota.Authentication.Azure.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-net/issues/35010
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1734

Version was already bumped via https://github.com/microsoft/kiota-authentication-azure-dotnet/pull/67