### PR TITLE
Revert "Bump coverlet.msbuild from 6.0.0 to 6.0.1"

### DIFF
--- a/Microsoft.Kiota.Authentication.Azure.Tests/Microsoft.Kiota.Authentication.Azure.Tests.csproj
+++ b/Microsoft.Kiota.Authentication.Azure.Tests/Microsoft.Kiota.Authentication.Azure.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />


### PR DESCRIPTION
Reverts microsoft/kiota-authentication-azure-dotnet#173

Coverage information is not emitted anymore
https://github.com/microsoft/kiota-authentication-azure-dotnet/actions/runs/7991469661/job/21822685767
https://github.com/microsoft/kiota-authentication-azure-dotnet/actions/runs/7929005111/job/21648389253